### PR TITLE
feat(window): support vim.o.winborder

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ local DEFAULT_SETTINGS = {
 
         ---@since 1.0.0
         -- The border to use for the UI window. Accepts same border values as |nvim_open_win()|.
-        border = "none",
+        border = nil,
 
         ---@since 1.11.0
         -- The backdrop opacity. 0 is fully opaque, 100 is fully transparent.

--- a/doc/mason.txt
+++ b/doc/mason.txt
@@ -329,7 +329,7 @@ Example:
 
             ---@since 1.0.0
             -- The border to use for the UI window. Accepts same border values as |nvim_open_win()|.
-            border = "none",
+            border = nil,
 
             ---@since 1.11.0
             -- The backdrop opacity. 0 is fully opaque, 100 is fully transparent.

--- a/lua/mason-core/ui/display.lua
+++ b/lua/mason-core/ui/display.lua
@@ -185,7 +185,7 @@ local function create_popup_window_opts(opts, sizes_only)
     local width = calc_size(settings.current.ui.width, columns)
     local row = math.floor((lines - height) / 2)
     local col = math.floor((columns - width) / 2)
-    if opts.border ~= "none" then
+    if opts.border ~= "none" or vim.o.winborder then
         row = math.max(row - 1, 0)
         col = math.max(col - 1, 0)
     end
@@ -201,7 +201,7 @@ local function create_popup_window_opts(opts, sizes_only)
     }
 
     if not sizes_only then
-        popup_layout.border = opts.border
+        popup_layout.border = opts.border or vim.o.winborder
     end
 
     return popup_layout
@@ -215,6 +215,7 @@ local function create_backdrop_window_opts()
         row = 0,
         col = 0,
         style = "minimal",
+        border = "none",
         focusable = false,
         zindex = 44,
     }

--- a/lua/mason/settings.lua
+++ b/lua/mason/settings.lua
@@ -75,7 +75,7 @@ local DEFAULT_SETTINGS = {
 
         ---@since 1.0.0
         -- The border to use for the UI window. Accepts same border values as |nvim_open_win()|.
-        border = "none",
+        border = nil,
 
         ---@since 1.11.0
         -- The backdrop opacity. 0 is fully opaque, 100 is fully transparent.

--- a/lua/mason/ui/instance.lua
+++ b/lua/mason/ui/instance.lua
@@ -725,7 +725,7 @@ update_registry_info()
 
 window.init {
     effects = effects,
-    border = settings.current.ui.border,
+    border = settings.current.ui.border or vim.o.winborder,
     winhighlight = {
         "NormalFloat:MasonNormal",
     },


### PR DESCRIPTION
vim.o.winborder is an option that: Defines the default border style of floating windows. The default value is empty, which is equivalent to "none"

This PR adds support for this option and fixes bugs related to it