### PR TITLE
Fix backdrop in cases where `winborder` is set

### DIFF
--- a/lua/mason-core/ui/display.lua
+++ b/lua/mason-core/ui/display.lua
@@ -217,6 +217,7 @@ local function create_backdrop_window_opts()
         style = "minimal",
         focusable = false,
         zindex = 44,
+        border = "none",
     }
 end
 


### PR DESCRIPTION
As of Neovim 0.11 there's a new default setting for floating window borders `winborder` that appears to not play well with the backdrop stuff.

This PR sets border to none for the backdrop. I've attached 2 screenshots of before and after:

**BEFORE:**
![CleanShot 2025-04-13 at 18 54 37](https://github.com/user-attachments/assets/2e14a14d-6518-4d2d-afa3-108e052a394c)

**AFTER:**
![CleanShot 2025-04-13 at 18 54 21](https://github.com/user-attachments/assets/85fed30b-44bf-4a7b-b1cf-e40a2f9c5e45)
