### PR TITLE
feat(ensure_installed): add ensure_installed option

### DIFF
--- a/lua/mason/init.lua
+++ b/lua/mason/init.lua
@@ -27,17 +27,20 @@ function M.setup(config)
         Registry.sources:append(registry)
     end
 
-    local commands = require "mason.api.command"
+    local Command = require "mason.api.command"
     setup_autocmds()
 
-    local pkg_names_to_install = {}
-    for _, pkg_name in ipairs(settings.current.ensure_installed or {}) do
-        if not Registry.is_installed(pkg_name) then
-            table.insert(pkg_names_to_install, pkg_name)
+    local Package = require "mason-core.package"
+    local pkgs_to_install = {}
+    for _, pkg_identifier in ipairs(settings.current.ensure_installed or {}) do
+        local pkg_name, _ = Package.Parse(pkg_identifier)
+        local ok, pkg = pcall(Registry.get_package, pkg_name)
+        if ok and not pkg:is_installed() and not pkg:is_installing() then
+            table.insert(pkgs_to_install, pkg_identifier)
         end
     end
-    if not vim.tbl_isempty(pkg_names_to_install) then
-        commands.MasonInstall(pkg_names_to_install)
+    if not vim.tbl_isempty(pkgs_to_install) then
+        Command.MasonInstall(pkgs_to_install)
     end
 
     M.has_setup = true

--- a/lua/mason/init.lua
+++ b/lua/mason/init.lua
@@ -27,8 +27,19 @@ function M.setup(config)
         Registry.sources:append(registry)
     end
 
-    require "mason.api.command"
+    local commands = require "mason.api.command"
     setup_autocmds()
+
+    local pkg_names_to_install = {}
+    for _, pkg_name in ipairs(settings.current.ensure_installed or {}) do
+        if not Registry.is_installed(pkg_name) then
+            table.insert(pkg_names_to_install, pkg_name)
+        end
+    end
+    if not vim.tbl_isempty(pkg_names_to_install) then
+        commands.MasonInstall(pkg_names_to_install)
+    end
+
     M.has_setup = true
 end
 

--- a/lua/mason/settings.lua
+++ b/lua/mason/settings.lua
@@ -8,6 +8,10 @@ local DEFAULT_SETTINGS = {
     -- The directory in which to install packages.
     install_root_dir = path.concat { vim.fn.stdpath "data", "mason" },
 
+    ---@since 2.0.1
+    -- Ensures the specified package names are installed.
+    ensure_installed = {},
+
     ---@since 1.0.0
     -- Where Mason should put its bin location in your PATH. Can be one of:
     -- - "prepend" (default, Mason's bin location is put first in PATH)


### PR DESCRIPTION
Fixes https://github.com/mason-org/mason.nvim/issues/1713.

Tested locally and it works:
```lua
{
  "andreihh/mason.nvim",
  branch = "ensure_installed",
  opts = { ensure_installed = { "lua-language-server@3.13.0", "stylua" } },
},
```

Implementation based on https://github.com/mason-org/mason-lspconfig.nvim/blob/main/lua/mason-lspconfig/features/ensure_installed.lua.