### PR TITLE
feat(pypi): add setting to respect `g:python3_host_prog` if set

### DIFF
--- a/lua/mason-core/installer/managers/pypi.lua
+++ b/lua/mason-core/installer/managers/pypi.lua
@@ -9,6 +9,7 @@ local pep440 = require "mason-core.pep440"
 local platform = require "mason-core.platform"
 local providers = require "mason-core.providers"
 local semver = require "mason-core.semver"
+local settings = require "mason.settings"
 local spawn = require "mason-core.spawn"
 
 local M = {}
@@ -85,6 +86,9 @@ local function create_venv(pkg)
 
     -- 1. Resolve stock python3 installation.
     local stock_candidates = platform.is.win and { "python", "python3" } or { "python3", "python" }
+    if settings.current.pip.use_python3_host_prog and vim.g.python3_host_prog then
+        table.insert(stock_candidates, 1, vim.g.python3_host_prog)
+    end
     local stock_target = resolve_python3(stock_candidates)
     if stock_target then
         log.fmt_debug("Resolved stock python3 installation version %s", stock_target.version)

--- a/lua/mason/health.lua
+++ b/lua/mason/health.lua
@@ -214,6 +214,9 @@ local function check_languages()
         check_thunk { cmd = "julia", args = { "--version" }, name = "julia", relaxed = true },
         function()
             local python = platform.is.win and "python" or "python3"
+            if settings.current.pip.use_python3_host_prog and vim.g.python3_host_prog then
+                python = vim.g.python3_host_prog
+            end
             check { cmd = python, args = { "--version" }, name = "python", relaxed = true }
             check { cmd = python, args = { "-m", "pip", "--version" }, name = "pip", relaxed = true }
             check {

--- a/lua/mason/settings.lua
+++ b/lua/mason/settings.lua
@@ -66,6 +66,10 @@ local DEFAULT_SETTINGS = {
         --
         -- Example: { "--proxy", "https://proxyserver" }
         install_args = {},
+
+        ---@since 2.0.1
+        -- Respect the `vim.g.python3_host_prog` while resolving packages from PyPI
+        use_python3_host_prog = false,
     },
 
     ui = {


### PR DESCRIPTION
Add a setting to respect `g:python3_host_prog` (if set) while resolving packages from PyPI. Should resolve #1635 #1907 

Usage,

```lua
require("mason").setup({
  pip = {
    use_python3_host_prog = true,
  },
})
```