### PR TITLE
fix(border): only set border to none if winborder doesn't exist

### DIFF
--- a/lua/mason/ui/instance.lua
+++ b/lua/mason/ui/instance.lua
@@ -740,12 +740,8 @@ end
 
 local border = settings.current.ui.border
 
-if border == nil then
-    if vim.fn.has "nvim-0.11" == 1 then
-        border = vim.o.winborder
-    else
-        border = "none"
-    end
+if border == nil and vim.fn.exists "&winborder" == 0 then
+    border = "none"
 end
 
 window.init {


### PR DESCRIPTION
Problem: Custom border characters in winborder was just added. It needs to be a list of characters. `vim.o.winbar` gives the string value with comma separated items which is invalid.

Solution: Just never explicitly set the border if winborder option exists. From the docs of winborder:

> 	Defines the default border style of floating windows. The default value
	is empty, which is equivalent to "none".