### PR TITLE
fix(process): Close check handle

### DIFF
--- a/lua/mason-core/process.lua
+++ b/lua/mason-core/process.lua
@@ -215,6 +215,7 @@ function M.spawn(cmd, opts, callback)
                 end
             end
             check:stop()
+            check:close()
             callback(successful, exit_code, signal)
         end)
 


### PR DESCRIPTION
[Neovim documentation](https://neovim.io/doc/user/luvref.html#uv_check_t) doesn't make it very clear, but checks are handles and need to be closed.

Neovim will close them after time specified in [`src/nvim/event/loop.c:loop_close()`](https://github.com/neovim/neovim/blob/628d569a594c762952b769776b9c79221fdb23d0/src/nvim/event/loop.c#L167), but at the cost of exit code signifying something went wrong.

I saw the fix in [Neovim codebase](https://github.com/neovim/neovim/blob/dff78f580dfae583023b20aa58e46e616607bdb6/runtime/lua/vim/_system.lua#L365).

There's one more `new_check` call in this plugin, in [`InstallHandle.lua`](https://github.com/mason-org/mason.nvim/blob/197f6352c276bbc2d25541dfce00ec50d1a4e88f/lua/mason-core/installer/InstallHandle.lua#L175). I _think_ it might need closing as well, but I see it also calls `__clear_event_handlers` which I am not familiar with.

Fixes #1994