### PR TITLE
feat(compiler): make `supported_platforms` a universal source field

### DIFF
--- a/lua/mason-core/installer/compiler/compilers/cargo.lua
+++ b/lua/mason-core/installer/compiler/compilers/cargo.lua
@@ -1,45 +1,37 @@
 local Result = require "mason-core.result"
 local _ = require "mason-core.functional"
 local providers = require "mason-core.providers"
-local util = require "mason-core.installer.compiler.util"
 
 local M = {}
 
 ---@class CargoSource : RegistryPackageSource
----@field supported_platforms? string[]
 
 ---@param source CargoSource
 ---@param purl Purl
 function M.parse(source, purl)
-    return Result.try(function(try)
-        if source.supported_platforms then
-            try(util.ensure_valid_platform(source.supported_platforms))
-        end
+    local repository_url = _.path({ "qualifiers", "repository_url" }, purl)
 
-        local repository_url = _.path({ "qualifiers", "repository_url" }, purl)
-
-        local git
-        if repository_url then
-            git = {
-                url = repository_url,
-                rev = _.path({ "qualifiers", "rev" }, purl) == "true",
-            }
-        end
-
-        ---@type string?
-        local features = _.path({ "qualifiers", "features" }, purl)
-        local locked = _.path({ "qualifiers", "locked" }, purl)
-
-        ---@class ParsedCargoSource : ParsedPackageSource
-        local parsed_source = {
-            crate = purl.name,
-            version = purl.version,
-            features = features,
-            locked = locked ~= "false",
-            git = git,
+    local git
+    if repository_url then
+        git = {
+            url = repository_url,
+            rev = _.path({ "qualifiers", "rev" }, purl) == "true",
         }
-        return parsed_source
-    end)
+    end
+
+    ---@type string?
+    local features = _.path({ "qualifiers", "features" }, purl)
+    local locked = _.path({ "qualifiers", "locked" }, purl)
+
+    ---@class ParsedCargoSource : ParsedPackageSource
+    local parsed_source = {
+        crate = purl.name,
+        version = purl.version,
+        features = features,
+        locked = locked ~= "false",
+        git = git,
+    }
+    return Result.success(parsed_source)
 end
 
 ---@async

--- a/lua/mason-core/installer/compiler/compilers/gem.lua
+++ b/lua/mason-core/installer/compiler/compilers/gem.lua
@@ -1,30 +1,22 @@
 local Result = require "mason-core.result"
 local _ = require "mason-core.functional"
 local providers = require "mason-core.providers"
-local util = require "mason-core.installer.compiler.util"
 
 local M = {}
 
 ---@class GemSource : RegistryPackageSource
----@field supported_platforms? string[]
 ---@field extra_packages? string[]
 
 ---@param source GemSource
 ---@param purl Purl
 function M.parse(source, purl)
-    return Result.try(function(try)
-        if source.supported_platforms then
-            try(util.ensure_valid_platform(source.supported_platforms))
-        end
-
-        ---@class ParsedGemSource : ParsedPackageSource
-        local parsed_source = {
-            package = purl.name,
-            version = purl.version,
-            extra_packages = source.extra_packages,
-        }
-        return parsed_source
-    end)
+    ---@class ParsedGemSource : ParsedPackageSource
+    local parsed_source = {
+        package = purl.name,
+        version = purl.version,
+        extra_packages = source.extra_packages,
+    }
+    return Result.success(parsed_source)
 end
 
 ---@async

--- a/lua/mason-core/installer/compiler/compilers/pypi.lua
+++ b/lua/mason-core/installer/compiler/compilers/pypi.lua
@@ -2,36 +2,28 @@ local Result = require "mason-core.result"
 local _ = require "mason-core.functional"
 local providers = require "mason-core.providers"
 local settings = require "mason.settings"
-local util = require "mason-core.installer.compiler.util"
 
 local M = {}
 
 ---@class PypiSource : RegistryPackageSource
 ---@field extra_packages? string[]
----@field supported_platforms? string[]
 
 ---@param source PypiSource
 ---@param purl Purl
 function M.parse(source, purl)
-    return Result.try(function(try)
-        if source.supported_platforms then
-            try(util.ensure_valid_platform(source.supported_platforms))
-        end
+    ---@class ParsedPypiSource : ParsedPackageSource
+    local parsed_source = {
+        package = purl.name,
+        version = purl.version --[[ @as string ]],
+        extra = _.path({ "qualifiers", "extra" }, purl),
+        extra_packages = source.extra_packages,
+        pip = {
+            upgrade = settings.current.pip.upgrade_pip,
+            extra_args = settings.current.pip.install_args,
+        },
+    }
 
-        ---@class ParsedPypiSource : ParsedPackageSource
-        local parsed_source = {
-            package = purl.name,
-            version = purl.version --[[ @as string ]],
-            extra = _.path({ "qualifiers", "extra" }, purl),
-            extra_packages = source.extra_packages,
-            pip = {
-                upgrade = settings.current.pip.upgrade_pip,
-                extra_args = settings.current.pip.install_args,
-            },
-        }
-
-        return parsed_source
-    end)
+    return Result.success(parsed_source)
 end
 
 ---@async

--- a/lua/mason-core/installer/compiler/init.lua
+++ b/lua/mason-core/installer/compiler/init.lua
@@ -72,6 +72,7 @@ end
 
 ---@param source RegistryPackageSource
 ---@param version string?
+---@return RegistryPackageSource
 local function coalesce_source(source, version)
     if version and source.version_overrides then
         for i = #source.version_overrides, 1, -1 do
@@ -116,6 +117,10 @@ function M.parse(spec, opts)
         end
 
         local source = coalesce_source(spec.source, opts.version)
+
+        if source.supported_platforms then
+            try(util.ensure_valid_platform(source.supported_platforms))
+        end
 
         ---@type Purl
         local purl = try(Purl.parse(source.id))

--- a/lua/mason-core/package/init.lua
+++ b/lua/mason-core/package/init.lua
@@ -60,6 +60,7 @@ Package.License = setmetatable({}, {
 
 ---@class RegistryPackageSource
 ---@field id string PURL-compliant identifier.
+---@field supported_platforms? Platform[]
 ---@field version_overrides? RegistryPackageSourceVersionOverride[]
 
 ---@class RegistryPackageSchemas

--- a/tests/mason-core/installer/compiler/compiler_spec.lua
+++ b/tests/mason-core/installer/compiler/compiler_spec.lua
@@ -13,9 +13,6 @@ local dummy_compiler = {
     ---@param opts PackageInstallOpts
     parse = function(source, purl, opts)
         return Result.try(function(try)
-            if source.supported_platforms then
-                try(util.ensure_valid_platform(source.supported_platforms))
-            end
             return {
                 package = purl.name,
                 extra_info = source.extra_info,

--- a/tests/mason-core/installer/compiler/compilers/cargo_spec.lua
+++ b/tests/mason-core/installer/compiler/compilers/cargo_spec.lua
@@ -82,15 +82,6 @@ describe("cargo compiler :: parsing", function()
             cargo.parse({}, purl { qualifiers = { locked = "false" } })
         )
     end)
-
-    it("should check supported platforms", function()
-        assert.same(
-            Result.failure "PLATFORM_UNSUPPORTED",
-            cargo.parse({
-                supported_platforms = { "VIC64" },
-            }, purl { qualifiers = { locked = "false" } })
-        )
-    end)
 end)
 
 describe("cargo compiler :: installing", function()

--- a/tests/mason-core/installer/compiler/compilers/gem_spec.lua
+++ b/tests/mason-core/installer/compiler/compilers/gem_spec.lua
@@ -24,10 +24,6 @@ describe("gem compiler :: parsing", function()
             gem.parse({ extra_packages = { "extra" } }, purl())
         )
     end)
-
-    it("should check supported platforms", function()
-        assert.same(Result.failure "PLATFORM_UNSUPPORTED", gem.parse({ supported_platforms = { "VIC64" } }, purl()))
-    end)
 end)
 
 describe("gem compiler :: installing", function()

--- a/tests/mason-core/installer/compiler/compilers/pypi_spec.lua
+++ b/tests/mason-core/installer/compiler/compilers/pypi_spec.lua
@@ -37,10 +37,6 @@ describe("pypi compiler :: parsing", function()
         )
         settings.set(settings._DEFAULT_SETTINGS)
     end)
-
-    it("should check supported platforms", function()
-        assert.same(Result.failure "PLATFORM_UNSUPPORTED", pypi.parse({ supported_platforms = { "VIC64" } }, purl()))
-    end)
 end)
 
 describe("pypi compiler :: installing", function()


### PR DESCRIPTION
Previously this field had to be handled separately in each source type
(currently only supported by `cargo`, `gem`, `pypi`). This
backwards-compatible change makes `supported_platforms` a universal
top-level field on the `source:` object, meaning it'll be parsed for
each source type.

PR to modify the schema: https://github.com/mason-org/registry-schema/pull/17.