### PR TITLE
404 erasure

### DIFF
--- a/lua/mason/ui/components/help/init.lua
+++ b/lua/mason/ui/components/help/init.lua
@@ -134,10 +134,6 @@ local function GenericHelp(state)
                     p.none "- ",
                     p.highlight "https://github.com/mason-org/mason.nvim/blob/main/CONTRIBUTING.md",
                 },
-                {
-                    p.none "- ",
-                    p.highlight "https://github.com/mason-org/mason.nvim/blob/main/doc/reference.md",
-                },
             },
         }),
         Ui.EmptyLine(),


### PR DESCRIPTION
[This](https://github.com/mason-org/mason.nvim/commit/6a7662760c515c74f2c37fc825776ead65d307f9) commit removed the reference.md file, so the link to it on the help screen is broken now; as a partial substitute for the info provided in that file I think that the mason-registry* lua module entries in the helpfile could be useful for new contributors, though it is likely redundant since other sections of the helpfile are referred to twice on that page. 

Another (likely stupid option): the [removed file](https://github.com/mason-org/mason.nvim/commit/6a7662760c515c74f2c37fc825776ead65d307f9#diff-533e91df00cb2ac6964b9e3061be545affb88b21451c63b40bf39fdd99320020) itself could be linked to; though it's outdated, most of the functions documented there still exist, so perhaps that would be more useful for someone wanting to familiarize themself with the api than just reading the source code? (though the parameters themselves may have changed too) 

For a PR deleting just deleting 4 lines, I'm definitely overthinking this. Nonetheless, I felt impelled to share my thoughts on supplementary documentation, as I would've included a replacement in the commit, but the discretion for that decision felt more appropriately bestowed to the actual developers than myself.
