### PR TITLE
feat(platform): detect Termux (Android/Bionic) as glibc-compatible

### DIFF
--- a/lua/mason-core/platform.lua
+++ b/lua/mason-core/platform.lua
@@ -63,8 +63,10 @@ local get_libc = _.lazy(function()
         end
     end
     -- Termux-specific detection (Android/Bionic)
-    if uname.sysname == "Linux" and (vim.env.TERMUX_VERSION or (vim.env.PREFIX and vim.env.PREFIX:find("com.termux"))) then
-        return "glibc"  -- Bionic is glibc-compatible for LSP servers
+    if
+        uname.sysname == "Linux" and (vim.env.TERMUX_VERSION or (vim.env.PREFIX and vim.env.PREFIX:find "com.termux"))
+    then
+        return "glibc" -- Bionic is glibc-compatible for LSP servers
     end
 end)
 

--- a/lua/mason-core/platform.lua
+++ b/lua/mason-core/platform.lua
@@ -62,6 +62,10 @@ local get_libc = _.lazy(function()
             return "glibc"
         end
     end
+    -- Termux-specific detection (Android/Bionic)
+    if uname.sysname == "Linux" and (vim.env.TERMUX_VERSION or (vim.env.PREFIX and vim.env.PREFIX:find("com.termux"))) then
+        return "glibc"  -- Bionic is glibc-compatible for LSP servers
+    end
 end)
 
 -- Most of the code that calls into these functions executes outside of the main event loop, where API/fn functions are

--- a/tests/mason-core/platform_spec.lua
+++ b/tests/mason-core/platform_spec.lua
@@ -119,6 +119,19 @@ describe("platform", function()
         assert.is_false(platform().is.linux_arm64_gnu)
     end)
 
+    it("should detect Termux as glibc-compatible", function()
+        stub_linux()
+        stub_uname { machine = "aarch64", sysname = "Linux" }
+        -- Termux doesn't have getconf or ldd
+        stub(vim.fn, "executable")
+        vim.fn.executable.on_call_with("ldd").returns(0)
+        vim.fn.executable.on_call_with("getconf").returns(0)
+        -- Set Termux environment variables directly
+        vim.env.TERMUX_VERSION = "0.118.3"
+        vim.env.PREFIX = "/data/data/com.termux/files/usr"
+        assert.is_true(platform().is.linux_arm64_gnu)
+    end)
+
     it("should be able to detect correct triple based on sysname", function()
         stub_linux()
         stub_uname { machine = "aarch64", sysname = "OpenBSD" }


### PR DESCRIPTION
Add explicit detection for Termux environment via TERMUX_VERSION or PREFIX environment variables. Bionic libc (used by Android/Termux) is glibc-compatible for most LSP server use cases.

Fixes #1602
Related to #306